### PR TITLE
docs: user-side VOMS proxy file generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ LABEL org.opencontainers.image.url='https://github.com/reanahub/reana-auth-vomsp
 LABEL org.opencontainers.image.documentation='https://github.com/reanahub/reana-auth-vomsproxy/blob/master/README.md'
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.vendor='reanahub'
-LABEL org.opencontainers.image.title='Image to obtain a VOMS proxy'
-LABEL org.opencontainers.image.description='Requires valid grid certificate to be mounted'
+LABEL org.opencontainers.image.title='Image to either set up VOMS proxy or optionally create it'
+LABEL org.opencontainers.image.description='Requires either VOMS proxy file or a valid Grid certificate to create it'
 
 COPY ca.repo /etc/yum.repos.d/ca.repo
 COPY wlcg-centos7.repo /etc/yum.repos.d/wlcg-centos7.repo

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ REANA Authentication VOMSproxy
 About
 =====
 
-``reana-auth-vomsproxy`` provides a container image for creating and renewing a
-VOMS proxy certificate. The container image includes no additional logic or
-libraries, just the bare minimum to support the VOMS client. The image is
-configured to support authentication for the four experiments at CERN's Large
-Hadron Collider (ALICE, ATLAS, CMS, LHCb), as well as `ESCAPE
+``reana-auth-vomsproxy`` provides a container image for either setting up or
+creating a VOMS proxy certificate. The container image includes no additional
+logic or libraries, just the bare minimum to support the VOMS client. The image
+is configured to support authentication for the four experiments at CERN's
+Large Hadron Collider (ALICE, ATLAS, CMS, LHCb), as well as `ESCAPE
 <https://projectescape.eu/>`_ Virtual Organization.
 
 ``reana-auth-vomsproxy`` was developed for use in the `REANA
@@ -27,26 +27,28 @@ Hadron Collider (ALICE, ATLAS, CMS, LHCb), as well as `ESCAPE
 Usage
 =====
 
-You can use ``reana-auth-vomsproxy`` as a base image, however it was built
-to be used as a sidecar container with the single purpose of refreshing the proxy certificate.
-Once obtained, the certificate is shared with the main container using common namespaces.
+You can use ``reana-auth-vomsproxy`` as a base image, however it was built to
+be used as a sidecar container for user jobs generated via
+``reana-job-controller`` with the single purpose of establishing the VOMS proxy
+authentication. The VOMS proxy file set up by the sidecar is shared with the
+main job container using common namespace.
 
 The end users can ask for VOMS authentication by means of declaring
-`voms_proxy: true`, more information `here
+`voms_proxy: true` workflow hints. For more information, please see `here
 <https://docs.reana.io/advanced-usage/access-control/voms-proxy/#setting-voms-proxy-requirement>`_.
 
-If you would like to try it locally, you can run:
+If you would like to try it out locally, you can run:
 
 .. code-block:: console
 
    $ docker run -i -t --rm -v $HOME/foo:/root/.globus/ reanahub/reana-auth-vomsproxy:1.0.0 /bin/bash
 
-Your local directory ``/foo`` should contain your ``usertcert.pem`` and
+Your local directory ``/foo`` should contain your ``usercert.pem`` and
 ``userkey.pem`` files. By default the VOMS client checks the directory
 ``/$HOME/.globus`` for the files needed. In this image that path results in
 ``/root/.globus/``.
 
-Inside the container a proxy can be obtained by specifying the Virtual
+Inside the container a VOMS proxy can be obtained by specifying the Virtual
 Organization, for example via:
 
 .. code-block:: console
@@ -56,16 +58,25 @@ Organization, for example via:
 Configuration
 =============
 
-Running the container and successfully obtaining a VOMS proxy certificate
-requires additional information and inputs:
+If you would like to use the sidecar to simply expose the VOMS proxy file
+generated on the client-side by the user, there is nothing to configure.
+
+If you would like to use the sidecar to create a VOMS proxy certificate from
+user Grid credentials, this requires additional information and inputs:
 
 - Grid user certificate: ``${HOME}/.globus/usercert.pem``
 - Grid user key: ``${HOME}/.globus/userkey.pem``
 - Grid user password
-- Virtual organisation membership (e.g. for CMS: ``cms``)
+- Virtual organisation membership (e.g. ``cms``)
 
 Changes
 =======
+
+Version 1.2.0 (UNRELEASED)
+--------------------------
+
+- Changes documentation to better expose two usage modes, the client-side and
+  the server-side generation of VOMS proxy file.
 
 Version 1.1.0 (2022-08-10)
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ user Grid credentials, this requires additional information and inputs:
 Changes
 =======
 
-Version 1.2.0 (UNRELEASED)
+Version 1.2.0 (2022-10-11)
 --------------------------
 
 - Changes documentation to better expose two usage modes, the client-side and


### PR DESCRIPTION
Clarifies documentation that there are two ways how the use this sidecar image, either rely on VOMS proxy file generated on the client-side (useful for multi-user deployments), or create VOMS proxy file inside the sidecar from Grid credentials (useful for single-user deployments where users trust uploading their Grid credentials as Kubernetes secrets).

Closes #16.