### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022 CERN.
+# Copyright (C) 2020, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Dockerfile compliance
-        run: docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+        run: docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 
   build-docker:
     runs-on: ubuntu-20.04
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build -t reanahub/reana-auth-vomsproxy .
+        run: docker build -t docker.io/reanahub/reana-auth-vomsproxy .
 
       - name: Test image
-        run: docker run -i --rm reanahub/reana-auth-vomsproxy voms-proxy-info 2>&1 | grep "Proxy not found"
+        run: docker run -i --rm docker.io/reanahub/reana-auth-vomsproxy voms-proxy-info 2>&1 | grep "Proxy not found"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cern/cc7-base:20220601-1
+FROM docker.io/cern/cc7-base:20220601-1
 
 ARG DATE
 ARG VERSION

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ If you would like to try it out locally, you can run:
 
 .. code-block:: console
 
-   $ docker run -i -t --rm -v $HOME/foo:/root/.globus/ reanahub/reana-auth-vomsproxy:1.0.0 /bin/bash
+   $ docker run -i -t --rm -v $HOME/foo:/root/.globus/ docker.io/reanahub/reana-auth-vomsproxy:1.0.0 /bin/bash
 
 Your local directory ``/foo`` should contain your ``usercert.pem`` and
 ``userkey.pem`` files. By default the VOMS client checks the directory


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.