### PR TITLE
ci(commitlint): check for the presence of concrete PR number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          npx commitlint --from HEAD~1 --to HEAD --verbose
+          ./run-tests.sh --check-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-20.04

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,7 +28,7 @@ check_commitlint () {
 }
 
 check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \;
+    find . -name "*.sh" -exec shellcheck {} \+
 }
 
 check_all () {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,13 +12,14 @@ set -o nounset
 check_commitlint () {
     from=${2:-master}
     to=${3:-HEAD}
+    pr=${4:-[0-9]+}
     npx commitlint --from="$from" --to="$to"
     found=0
     while IFS= read -r line; do
-        if echo "$line" | grep -qP "\(\#[0-9]+\)$"; then
+        if echo "$line" | grep -qP "\(\#$pr\)$"; then
             true
         else
-            echo "✖   PR number missing in $line"
+            echo "✖   Headline does not end by '(#$pr)' PR number: $line"
             found=1
         fi
     done < <(git log "$from..$to" --format="%s")


### PR DESCRIPTION
- ci(commitlint): check for the presence of concrete PR number

    Enrich commitlint checker in order to check the precise PR number in the
    commit log headline.

- ci(shellcheck): fix exit code propagation

    Return properly the exit code status of shellcheck command when looping
    through shell script files.
