### PR TITLE
chore(master): backfill missing copyright years

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2023, 2024 CERN.
+# Copyright (C) 2020, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2020, 2022, 2023, 2024 CERN.
+Copyright (C) 2020, 2022, 2023, 2024, 2025, 2026 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024, 2025 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Update source file copyright headers and top-level LICENSE files
to include the years in which each file was modified according to
git history, without following renames.

Closes reanahub/reana#973